### PR TITLE
Added withManager HOC to library exports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,3 @@
-export { ScrollManager } from './ScrollManager';
+export { ScrollManager, withManager } from './ScrollManager';
 export { WindowScroller } from './WindowScroller';
 export { ElementScroller } from './ElementScroller';


### PR DESCRIPTION
There could be places where you just need `withManager` HOC without `<WindowScroller />` or `<ElementScroller />` components usage, so it would be useful to add it to library exports