### PR TITLE
Bugfix for ScrollX / ScrollY in IE11

### DIFF
--- a/src/ScrollManager.js
+++ b/src/ScrollManager.js
@@ -123,8 +123,8 @@ export class ScrollManager extends React.Component {
   }
 
   _savePositions() {
-    const { pageXOffset, pageYOffset } = window;
-    this._savePosition('window', { pageXOffset, pageYOffset });
+    const { pageXOffset: scrollX, pageYOffset: scrollY } = window;
+    this._savePosition('window', { scrollX, scrollY });
     for (const scrollKey in this._scrollableNodes) {
       const node = this._scrollableNodes[scrollKey];
       const { scrollLeft, scrollTop } = node;
@@ -183,17 +183,17 @@ export class ScrollManager extends React.Component {
   _restoreWindow() {
     const scrollKey = 'window';
     const position = this._loadPosition(scrollKey);
-    const { pageXOffset = 0, pageYOffset = 0 } = position || {};
-    debug('restore', this._locationKey, scrollKey, pageXOffset, pageYOffset);
+    const { scrollX = 0, scrollY = 0 } = position || {};
+    debug('restore', this._locationKey, scrollKey, scrollX, scrollY);
 
     this._cancelDeferred(scrollKey);
     const attemptScroll = () => {
-      window.scrollTo(pageXOffset, pageYOffset);
-      return window.pageXOffset === pageXOffset && window.pageYOffset === pageYOffset;
+      window.scrollTo(scrollX, scrollY);
+      return window.pageXOffset === scrollX && window.pageYOffset === scrollY;
     };
     if (!attemptScroll()) {
       const failedScroll = () => {
-        debug(`Could not scroll ${scrollKey} to (${pageXOffset}, ${pageYOffset})` +
+        debug(`Could not scroll ${scrollKey} to (${scrollX}, ${scrollY})` +
           `; scroll size is (${document.body.scrollWidth}, ${document.body.scrollHeight})`);
       };
 

--- a/src/ScrollManager.js
+++ b/src/ScrollManager.js
@@ -123,8 +123,8 @@ export class ScrollManager extends React.Component {
   }
 
   _savePositions() {
-    const { scrollX, scrollY } = window;
-    this._savePosition('window', { scrollX, scrollY });
+    const { pageXOffset, pageYOffset } = window;
+    this._savePosition('window', { pageXOffset, pageYOffset });
     for (const scrollKey in this._scrollableNodes) {
       const node = this._scrollableNodes[scrollKey];
       const { scrollLeft, scrollTop } = node;
@@ -183,17 +183,17 @@ export class ScrollManager extends React.Component {
   _restoreWindow() {
     const scrollKey = 'window';
     const position = this._loadPosition(scrollKey);
-    const { scrollX = 0, scrollY = 0 } = position || {};
-    debug('restore', this._locationKey, scrollKey, scrollX, scrollY);
+    const { pageXOffset = 0, pageYOffset = 0 } = position || {};
+    debug('restore', this._locationKey, scrollKey, pageXOffset, pageYOffset);
 
     this._cancelDeferred(scrollKey);
     const attemptScroll = () => {
-      window.scrollTo(scrollX, scrollY);
-      return window.scrollX === scrollX && window.scrollY === scrollY;
+      window.scrollTo(pageXOffset, pageYOffset);
+      return window.pageXOffset === pageXOffset && window.pageYOffset === pageYOffset;
     };
     if (!attemptScroll()) {
       const failedScroll = () => {
-        debug(`Could not scroll ${scrollKey} to (${scrollX}, ${scrollY})` +
+        debug(`Could not scroll ${scrollKey} to (${pageXOffset}, ${pageYOffset})` +
           `; scroll size is (${document.body.scrollWidth}, ${document.body.scrollHeight})`);
       };
 

--- a/test/ScrollManager.stored.test.js
+++ b/test/ScrollManager.stored.test.js
@@ -10,8 +10,8 @@ window.sessionStorage.setItem('scroll', JSON.stringify({
   positions: {
     [locationKey]: {
       window: {
-        scrollX: 10,
-        scrollY: 20
+        pageXOffset: 10,
+        pageYOffset: 20
       },
       main: {
         scrollLeft: 30,

--- a/test/ScrollManager.stored.test.js
+++ b/test/ScrollManager.stored.test.js
@@ -10,8 +10,8 @@ window.sessionStorage.setItem('scroll', JSON.stringify({
   positions: {
     [locationKey]: {
       window: {
-        pageXOffset: 10,
-        pageYOffset: 20
+        scrollX: 10,
+        scrollY: 20
       },
       main: {
         scrollLeft: 30,


### PR DESCRIPTION
This PR replaces `scrollX` and `scrollY` with `pageXOffset` and `pageYOffset` (which is basically the same) to get scroll-compatibility in IE11. It _does_ rename the properties in the local storage as well, but I don't know if this would be considered a breaking change for anyone?

See https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollY#Notes for information about the cross-browser compatibility. `pageXOffset` is a safer bet. :)