### PR TITLE
fix: add explicit children prop typing

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -7,12 +7,18 @@ export interface ScrollManagerProps {
   timeout?: number;
 }
 
-export class ScrollManager extends React.Component<ScrollManagerProps> { }
+export class ScrollManager extends React.Component<
+  React.PropsWithChildren<ScrollManagerProps>
+> {}
 
-export class WindowScroller extends React.Component { }
+export class WindowScroller extends React.Component<
+  React.PropsWithChildren<{}>
+> {}
 
 export interface ElementScrollerProps {
   scrollKey: string;
 }
 
-export class ElementScroller extends React.Component<ElementScrollerProps> { }
+export class ElementScroller extends React.Component<
+  React.PropsWithChildren<ElementScrollerProps>
+> {}


### PR DESCRIPTION
The new @types/react@^18 package [ships with](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210) breaking changes. One such change is that `children` prop is no longer automatically included as part of the `React.Component` typing. Components need to opt-in to the `children` prop now.

This PR adds explicit `children` prop typing to the components the library exposes.